### PR TITLE
Change cryptobox-c repo to use HTTPS instead of SSH URL

### DIFF
--- a/mk/cryptobox-src.mk
+++ b/mk/cryptobox-src.mk
@@ -1,6 +1,6 @@
 CRYPTOBOX_VERSION := v0.8.3
 CRYPTOBOX         := cryptobox-$(CRYPTOBOX_VERSION)
-CRYPTOBOX_GIT_URL := git@github.com:wireapp/cryptobox-c.git
+CRYPTOBOX_GIT_URL := https://github.com/wireapp/cryptobox-c.git
 
 build/src/$(CRYPTOBOX):
 	mkdir -p build/src


### PR DESCRIPTION
So that there is no GitHub account needed to clone while compiling from source