### PR TITLE
Configure vendored libsodium with --disable-soname-versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,9 @@ libsodium: build/lib/libsodium.$(LIB_TYPE)
 build/lib/libsodium.$(LIB_TYPE): build/src/$(LIBSODIUM)
 	mkdir -p build/lib
 	cd build/src/$(LIBSODIUM) && \
-	./configure --prefix="$(CURDIR)/build/src/$(LIBSODIUM)/build" && make -j3 && make install
+	./configure --prefix="$(CURDIR)/build/src/$(LIBSODIUM)/build" \
+				--disable-soname-versions \
+		&& make -j3 && make install
 	cp build/src/$(LIBSODIUM)/build/lib/libsodium.$(LIB_TYPE) build/lib/
 # OSX name mangling
 ifeq ($(OS), darwin)


### PR DESCRIPTION
The distribution tarball includes only `libsodium.so`, not the soname-versioned symlink chain (ie. `libsodium.so -> libsodium.so.18.1.0`, `libsodium.so.18 -> libsodium.so.18.1.0`, `libsodium.so.18.1.0`). This confuses the runtime linker on Linux. Since `./configure --help` states that soname versions should be disable on Android, I opted to add this option rather than preserving the symlinks in the distribution tarball.