### PR TITLE
Refactor/move to universal toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-android/jni/*.so
 android/jni/include
+android/jni/x86
+android/jni/x86_64
+android/jni/arm64-v8a
+android/jni/armeabi-v7a
 bin/
 gen/
 libs/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ libs/
 obj/
 build/
 dist/
+output/
 local.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+FROM omnijar/rust:linux-musl
+
+USER root
+
+ENV PATH $PATH:/usr/local/sbin:/usr/sbin:/sbin
+
+####### BASE TOOLS #######
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless unzip clang
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+
+######## ANDROID #########
+
+RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
+RUN mv android-sdk_r24.4.1-linux.tgz /opt/
+RUN cd /opt && tar xzvf ./android-sdk_r24.4.1-linux.tgz
+ENV ANDROID_HOME /opt/android-sdk-linux/
+ENV PATH $ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$PATH
+RUN chmod -R 755 $ANDROID_HOME
+RUN echo y | android update sdk --no-ui --all --filter tools
+RUN echo y | android update sdk --no-ui --all --filter platform-tools
+RUN echo y | android update sdk --no-ui --all --filter extra-android-support
+RUN echo y | android update sdk --no-ui --all --filter android-23
+RUN echo y | android update sdk --no-ui --all --filter android-24
+RUN echo y | android update sdk --no-ui --all --filter android-25
+RUN echo y | android update sdk --no-ui --all --filter android-26
+RUN echo y | android update sdk --no-ui --all --filter android-27
+RUN echo y | android update sdk --no-ui --all --filter build-tools-23.0.3
+RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.0
+RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.1
+RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.3
+RUN echo y | android update sdk --no-ui --all --filter build-tools-26.0.0
+RUN echo y | android update sdk --no-ui --all --filter build-tools-26.0.1
+RUN echo y | android update sdk --no-ui --all --filter build-tools-27.0.3
+RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository
+RUN echo y | android update sdk --no-ui --all --filter extra-google-m2repository
+RUN echo y | android update sdk --no-ui --all --filter extra-google-google_play_services
+RUN echo y | android update sdk --no-ui --all --filter addon-google_apis-google-23
+
+ENV ANDROID_NDK_HOME /opt/android-ndk
+ENV ANDROID_NDK_VERSION r20
+RUN mkdir /opt/android-ndk-tmp && \
+    cd /opt/android-ndk-tmp && \
+    wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
+# uncompress
+    unzip -q android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
+# move to its final location
+    mv ./android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_HOME} && \
+# remove temp dir
+    cd ${ANDROID_NDK_HOME} && \
+    rm -rf /opt/android-ndk-tmp
+
+# add to PATH
+ENV PATH ${PATH}:${ANDROID_NDK_HOME}
+
+# # Install gradle
+# RUN apt-get install -y unzip
+# #ADD https://services.gradle.org/distributions/gradle-2.14.1-bin.zip /opt/
+# ADD gradle-2.14.1-bin.zip /opt/
+# RUN unzip /opt/gradle-2.14.1-bin.zip -d /opt
+# ENV GRADLE_HOME /opt/gradle-2.14.1
+# ENV PATH $GRADLE_HOME/bin:$PATH
+
+######### RUST ############
+
+USER rust
+
+RUN rustup install 1.36.0
+RUN rustup default 1.36.0
+RUN rustup target add armv7-linux-androideabi
+RUN rustup target add i686-linux-android
+RUN rustup target add aarch64-linux-android
+RUN rustup target add arm-linux-androideabi
+RUN rustup target add x86_64-linux-android
+
+ENV RUST_HOME ~/.rust
+
+WORKDIR ..
+RUN git clone https://github.com/wireapp/cryptobox-jni.git
+WORKDIR cryptobox-jni
+RUN git checkout refactor/move-to-universal-toolchain
+WORKDIR android
+RUN make dist
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ RUN rustup target add x86_64-linux-android
 
 ENV RUST_HOME ~/.rust
 
+ENV PKG_CONFIG_PATH=/home/rust/cryptobox-jni/android/build/libsodium-android-armv7-a/lib/pkgconfig
+
 WORKDIR /home/rust
 RUN git clone https://github.com/wireapp/cryptobox-jni.git --branch refactor/move-to-universal-toolchain --single-branch
 WORKDIR cryptobox-jni/android

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV PATH $PATH:/usr/local/sbin:/usr/sbin:/sbin
 ####### BASE TOOLS #######
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless unzip clang vim pkg-config
+RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless \
+    unzip clang vim pkg-config strace less
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ######## ANDROID #########
@@ -67,5 +68,5 @@ ENV RUST_HOME ~/.rust
 WORKDIR /home/rust
 RUN git clone https://github.com/wireapp/cryptobox-jni.git --branch refactor/move-to-universal-toolchain --single-branch
 WORKDIR cryptobox-jni/android
-# RUN make dist
+RUN make dist || echo "FAILED TO BUILD!!"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,7 @@ RUN chmod -R 755 $ANDROID_HOME
 RUN echo y | android update sdk --no-ui --all --filter tools
 RUN echo y | android update sdk --no-ui --all --filter platform-tools
 RUN echo y | android update sdk --no-ui --all --filter extra-android-support
-RUN echo y | android update sdk --no-ui --all --filter android-23
-RUN echo y | android update sdk --no-ui --all --filter android-24
-RUN echo y | android update sdk --no-ui --all --filter android-25
-RUN echo y | android update sdk --no-ui --all --filter android-26
 RUN echo y | android update sdk --no-ui --all --filter android-27
-RUN echo y | android update sdk --no-ui --all --filter build-tools-23.0.3
-RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.0
-RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.1
-RUN echo y | android update sdk --no-ui --all --filter build-tools-24.0.3
-RUN echo y | android update sdk --no-ui --all --filter build-tools-26.0.0
-RUN echo y | android update sdk --no-ui --all --filter build-tools-26.0.1
 RUN echo y | android update sdk --no-ui --all --filter build-tools-27.0.3
 RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository
 RUN echo y | android update sdk --no-ui --all --filter extra-google-m2repository
@@ -71,7 +61,6 @@ RUN rustup default 1.36.0
 RUN rustup target add armv7-linux-androideabi
 RUN rustup target add i686-linux-android
 RUN rustup target add aarch64-linux-android
-RUN rustup target add arm-linux-androideabi
 RUN rustup target add x86_64-linux-android
 
 ENV RUST_HOME ~/.rust

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH $PATH:/usr/local/sbin:/usr/sbin:/sbin
 ####### BASE TOOLS #######
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless unzip clang vim
+RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless unzip clang vim pkg-config
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ######## ANDROID #########

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ ENV ANDROID_HOME /opt/android-sdk-linux
 ENV PATH $ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$PATH
 RUN echo y | android update sdk --no-ui --all --filter tools
 RUN echo y | android update sdk --no-ui --all --filter platform-tools
-RUN echo y | android update sdk --no-ui --all --filter extra-android-support
 RUN echo y | android update sdk --no-ui --all --filter android-27
 RUN echo y | android update sdk --no-ui --all --filter build-tools-27.0.3
 RUN echo y | android update sdk --no-ui --all --filter extra-android-m2repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
 RUN mv android-sdk_r24.4.1-linux.tgz /opt/
 RUN cd /opt && tar xzvf ./android-sdk_r24.4.1-linux.tgz
-ENV ANDROID_HOME /opt/android-sdk-linux/
+ENV ANDROID_HOME /opt/android-sdk-linux
 ENV PATH $ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$PATH
 RUN echo y | android update sdk --no-ui --all --filter tools
 RUN echo y | android update sdk --no-ui --all --filter platform-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,5 +81,5 @@ RUN git clone https://github.com/wireapp/cryptobox-jni.git
 WORKDIR cryptobox-jni
 RUN git checkout refactor/move-to-universal-toolchain
 WORKDIR android
-RUN make dist
+# RUN make dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
 RUN mv android-sdk_r24.4.1-linux.tgz /opt/
 RUN cd /opt && tar xzvf ./android-sdk_r24.4.1-linux.tgz
+ENV ANDROID_HOME /opt/android-sdk-linux/
 ENV PATH $ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$PATH
 RUN echo y | android update sdk --no-ui --all --filter tools
 RUN echo y | android update sdk --no-ui --all --filter platform-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,24 @@ ENV PATH $PATH:/usr/local/sbin:/usr/sbin:/sbin
 ####### BASE TOOLS #######
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless \
-    unzip clang vim pkg-config strace less g++-multilib libc6-dev-i386
+RUN apt-get install -qqy --no-install-recommends \
+	git \
+	wget \
+	build-essential \
+	gcc \
+	software-properties-common \
+	unzip \
+	clang \
+	vim \
+	pkg-config \
+	strace \
+	less \
+	g++-multilib \
+	libc6-dev-i386 \
+	sudo \
+	openjdk-8-jdk-headless \
+	openjdk-8-jre-headless
+	
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ######## ANDROID #########
@@ -66,6 +82,13 @@ ENV RUST_HOME ~/.rust
 
 ENV PKG_CONFIG_PATH=/home/rust/cryptobox-jni/android/build/libsodium-android-armv7-a/lib/pkgconfig
 
+######### ADDITIONAL TOOLS ############
+USER root
+RUN apt-get install -qqy --no-install-recommends \
+	zip
+USER rust
+
+######### Build ##############
 WORKDIR /home/rust
 COPY --chown=rust . cryptobox-jni
 WORKDIR cryptobox-jni/android

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/sbin:/usr/sbin:/sbin
 RUN apt-get update
 RUN apt-get upgrade -y
 RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless \
-    unzip clang vim pkg-config strace less
+    unzip clang vim pkg-config strace less g++-multilib libc6-dev-i386
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ######## ANDROID #########
@@ -70,5 +70,5 @@ ENV PKG_CONFIG_PATH=/home/rust/cryptobox-jni/android/build/libsodium-android-arm
 WORKDIR /home/rust
 RUN git clone https://github.com/wireapp/cryptobox-jni.git --branch refactor/move-to-universal-toolchain --single-branch
 WORKDIR cryptobox-jni/android
-RUN make dist || echo "FAILED TO BUILD!!"
+# RUN make dist || echo "FAILED TO BUILD!!"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM omnijar/rust:linux-musl
+FROM rust
 
 USER root
 
@@ -52,7 +52,7 @@ ENV PATH ${PATH}:${ANDROID_NDK_HOME}
 # ENV PATH $GRADLE_HOME/bin:$PATH
 
 ######### RUST ############
-
+RUN useradd rust -m
 USER rust
 
 RUN rustup install 1.36.0
@@ -67,7 +67,7 @@ ENV RUST_HOME ~/.rust
 ENV PKG_CONFIG_PATH=/home/rust/cryptobox-jni/android/build/libsodium-android-armv7-a/lib/pkgconfig
 
 WORKDIR /home/rust
-RUN git clone https://github.com/wireapp/cryptobox-jni.git --branch refactor/move-to-universal-toolchain --single-branch
+COPY --chown=rust . cryptobox-jni
 WORKDIR cryptobox-jni/android
-# RUN make dist || echo "FAILED TO BUILD!!"
+RUN make dist || echo "FAILED TO BUILD!!"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
 RUN mv android-sdk_r24.4.1-linux.tgz /opt/
 RUN cd /opt && tar xzvf ./android-sdk_r24.4.1-linux.tgz
+ENV PATH $ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$PATH
 RUN echo y | android update sdk --no-ui --all --filter tools
 RUN echo y | android update sdk --no-ui --all --filter platform-tools
 RUN echo y | android update sdk --no-ui --all --filter extra-android-support

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH $PATH:/usr/local/sbin:/usr/sbin:/sbin
 ####### BASE TOOLS #######
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless unzip clang
+RUN apt-get install -qqy --no-install-recommends git wget build-essential gcc software-properties-common openjdk-8-jre-headless unzip clang vim
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 ######## ANDROID #########
@@ -76,10 +76,8 @@ RUN rustup target add x86_64-linux-android
 
 ENV RUST_HOME ~/.rust
 
-WORKDIR ..
-RUN git clone https://github.com/wireapp/cryptobox-jni.git
-WORKDIR cryptobox-jni
-RUN git checkout refactor/move-to-universal-toolchain
-WORKDIR android
+WORKDIR /home/rust
+RUN git clone https://github.com/wireapp/cryptobox-jni.git --branch refactor/move-to-universal-toolchain --single-branch
+WORKDIR cryptobox-jni/android
 # RUN make dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,6 @@ ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 RUN wget https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz
 RUN mv android-sdk_r24.4.1-linux.tgz /opt/
 RUN cd /opt && tar xzvf ./android-sdk_r24.4.1-linux.tgz
-ENV ANDROID_HOME /opt/android-sdk-linux/
-ENV PATH $ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$PATH
-RUN chmod -R 755 $ANDROID_HOME
 RUN echo y | android update sdk --no-ui --all --filter tools
 RUN echo y | android update sdk --no-ui --all --filter platform-tools
 RUN echo y | android update sdk --no-ui --all --filter extra-android-support

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Run `./docker-build.sh` to start the build. It will download Android SDK and NDK
 
 Once the script is completed, you will find the result of the compilation copied to the `output/` folder.
 
+### Publishing
+
+In order to publish the binary to Bintray, you need to install the JFrog CLI (`jfrog-cli-go`) tool.
+
+- Create a version using `jfrog` CLI
+- Upload files to that version using the `jfrog` CLI. E.g:
+```
+/usr/local/bin/jfrog bt u "cryptobox-android-1.1.1.*" \
+	"wire-android/releases/cryptobox-android/1.1.1" \
+	"com/wire/cryptobox-android/1.1.1/"
+```
+
 ## Sample Application
 
 This project has a simple Android sample application that can be installed

--- a/README.md
+++ b/README.md
@@ -12,101 +12,11 @@ JNI bindings for the [cryptobox](https://github.com/wireapp/cryptobox) with supp
 
 ## Building
 
-### Host Architecture
+There is a Docker file that create an image to cross compile on all necessary platforms. You need to have Docker running on your machine.
 
-Besides common OS-specific development tooling, the following prerequisites
-are needed to build for the host architecture:
+Run `./docker-build.sh` to start the build. It will download Android SDK and NDK, so it will take a while.
 
-  * A Rust compiler (1.16.0 exactly).
-  * A Java compiler (1.6 or later).
-
-With that in place
-
-    make dist
-
-will leave a tarball in the `dist` directory containing all the binaries for
-your host architecture in the form of shared libraries, as well as a `.jar`
-file and the corresponding `javadoc` output.
-
-### Android
-
-Besides common OS-specific development tooling, the following prerequisites
-are needed to build for Android:
-
-  * The [Android SDK](http://developer.android.com/sdk/index.html) (The Android Studio IDE is not required).
-
-  * The [Android NDK](https://developer.android.com/ndk/downloads/index.html) (`r10d` or newer).
-
-  * A Java compiler (1.6 or later).
-
-  * A Rust compiler (1.16.0) that can cross-compile to the following
-    targets corresponding to the NDK toolchains:
-      * `armv7-linux-androideabi`
-      * `aarch64-linux-android`
-      * `i686-linux-android`
-      * `x86_64-unknown-linux-gnu`
-
-    It is recommended to use [rustup](https://github.com/rust-lang-nursery/rustup.rs) to
-    manage multiple Rust compiler toolchains. Using rustup, the following commands
-    will install the necessary target-specific Rust binaries needed for Android:
-
-        rustup target add armv7-linux-androideabi
-        rustup target add i686-linux-android
-        rustup target add aarch64-linux-android
-        rustup target add x86_64-unknown-linux-gnu
-
-    Alternatively a Rust compiler that supports the necessary targets can be built from source, e.g.:
-
-        ./configure \
-            --prefix=/where/to/install \
-            --arm-linux-androideabi-ndk=/path/to/android-ndk-toolchain-armeabi-v7a \
-            --aarch64-linux-android-ndk=/path/to/android-ndk-toolchain-arm64-v8a \
-            --i686-linux-android-ndk=/path/to/android-ndk-toolchain-x86 \
-            --x86_64-linux-android-ndk=/path/to/android-ndk-toolchain-x86_64 \
-            --target=arm-linux-androideabi,aarch64-linux-android,i686-linux-android,x86_64-unknown-linux-gnu
-        make -j4
-        make install
-
-  * The `ANDROID_NDK_HOME` environment variable must be set and point to the
-    home directory of the NDK installation.
-
-With the prerequisites in place, the Android build can be run with:
-
-    cd android && make dist
-
-The distribution artifacts will be in the `android/dist` directory, which includes
-an [Android Library Archive](http://tools.android.com/tech-docs/new-build-system/aar-format) (`.aar`).
-
-If [Maven](https://maven.apache.org) is installed (availble on [homebrew](https://formulae.brew.sh/formula/maven)), you can publish the aar to a your local Maven repository with the command:
-
-```
-mvn install:install-file \
-	-Dfile="<path to aar>" \
-	-DgroupId=com.wire \
-	-DartifactId=cryptobox-android \
-	-Dpackaging=aar \
-	-Dversion=<version number>
-```
-
-### Windows
-
-You need:
-
-  * [MSYS2](http://msys2.github.io/) with MinGW-w64 toolchains
-
-  * The pkg-config from MinGW-w64 toolchain
-
-        pacman -S mingw-w64-x86_64-pkg-config
-
-  * A Java compiler (1.6 or later)
-
-  * A Rust compiler (1.6 or newer) with GNU ABI
-
-  * The `JAVA_HOME` environment variable must be set correctly for MSYS2
-
-        export JAVA_HOME="/c/Program Files/Java/jdk1.8.0_rev"
-
-  * The `PATH` environment variable must include JDK and Rust for MSYS2
+Once the script is completed, you will find the result of the compilation copied to the `output/` folder.
 
 ## Sample Application
 

--- a/README.md
+++ b/README.md
@@ -37,15 +37,10 @@ are needed to build for Android:
 
   * The [Android NDK](https://developer.android.com/ndk/downloads/index.html) (`r10d` or newer).
 
-  * [NDK standalone toolchains](https://developer.android.com/ndk/guides/standalone_toolchain.html) for the following architectures:
-      * `armeabi-v7a`
-      * `arm64-v8a`
-      * `x86`
-
   * A Java compiler (1.6 or later).
 
   * A Rust compiler (1.16.0) that can cross-compile to the following
-    targets corresponding to the aforementioned NDK standalone toolchains:
+    targets corresponding to the NDK toolchains:
       * `armv7-linux-androideabi`
       * `aarch64-linux-android`
       * `i686-linux-android`
@@ -74,18 +69,6 @@ are needed to build for Android:
 
   * The `ANDROID_NDK_HOME` environment variable must be set and point to the
     home directory of the NDK installation.
-
-  * The `ANDROID_NDK_TOOLCHAIN_ARM` environment variable must be set and point
-    to the home directory of the `armeabi-v7a` standalone toolchain.
-
-  * The `ANDROID_NDK_TOOLCHAIN_X86` environment variable must be set and point
-    to the home directory of the `x86` standalone toolchain.
-
-  * The `ANDROID_NDK_TOOLCHAIN_AARCH64` environment variable must be set and point
-    to the home directory of the `arm64-v8a` standalone toolchain.
-
-  * The `ANDROID_NDK_TOOLCHAIN_X86_64` environment variable must be set and point
-    to the home directory of the `x86_64` standalone toolchain.
 
 With the prerequisites in place, the Android build can be run with:
 

--- a/android/Makefile
+++ b/android/Makefile
@@ -86,55 +86,20 @@ dist: compile dist-tar dist-aar
 include ../mk/cryptobox-src.mk
 
 .PHONY: cryptobox
-cryptobox: jni/armeabi-v7a/libcryptobox.so jni/x86/libcryptobox.so jni/x86_64/libcryptobox.so jni/arm64-v8a/libcryptobox.so jni/include/cbox.h
+cryptobox: jni/armeabi-v7a/libcryptobox.so jni/include/cbox.h
 
 jni/armeabi-v7a/libcryptobox.so: libsodium-armeabi-v7a | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export SODIUM_LIB_DIR=../../libsodium-android-armv7-a/lib && \
+	export SODIUM_SHARED=1 && \
 	cargo rustc --lib --release --target=armv7-linux-androideabi -- \
-		-L ../../libsodium-android-armv7-a/lib \
-		-l sodium \
-		-C ar=arm-linux-androideabi-ar \
-		-C linker=armv7a-linux-androideabi16-clang \
-		-C link_args="-Wl,-soname,libcryptobox.so"
+	               -C ar=arm-linux-androideabi-ar \
+	               -C linker=armv7a-linux-androideabi16-clang 
 	mkdir -p jni/armeabi-v7a
 	cp build/src/$(CRYPTOBOX_NAME)/target/armv7-linux-androideabi/release/libcryptobox.so jni/armeabi-v7a/libcryptobox.so
 
-jni/x86/libcryptobox.so: libsodium-x86 | build/src/$(CRYPTOBOX_NAME)
-	cd build/src/$(CRYPTOBOX_NAME) && \
-	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
-	cargo rustc --lib --release --target=i686-linux-android -- \
-		-L ../../libsodium-android-x86/lib \
-		-l sodium \
-		-C ar=i686-linux-android-ar \
-		-C linker=i686-linux-android16-clang \
-		-C link_args="-Wl,-soname,libcryptobox.so"
-	mkdir -p jni/x86
-	cp build/src/$(CRYPTOBOX_NAME)/target/i686-linux-android/release/libcryptobox.so jni/x86/libcryptobox.so
 
-jni/x86_64/libcryptobox.so: libsodium-x86_64 | build/src/$(CRYPTOBOX_NAME)
-	cd build/src/$(CRYPTOBOX_NAME) && \
-	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
-	cargo rustc -v --lib --release --target=x86_64-linux-android -- \
-		-L ../../libsodium-android-x86_64/lib \
-		-l sodium \
-		-C ar=x86_64-linux-android-ar \
-		-C linker=x86_64-linux-android21-clang \
-		-C link_args="-Wl,-soname,libcryptobox.so"
-	mkdir -p jni/x86_64
-	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-linux-android/release/libcryptobox.so jni/x86_64/libcryptobox.so
-
-jni/arm64-v8a/libcryptobox.so: libsodium-arm64-v8a | build/src/$(CRYPTOBOX_NAME)
-	cd build/src/$(CRYPTOBOX_NAME) && \
-	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
-	cargo rustc --lib --release --target=aarch64-linux-android -- \
-		-L ../../libsodium-android-armv8-a/lib \
-		-l sodium \
-		-C ar=aarch64-linux-android-ar \
-		-C linker=aarch64-linux-android21-clang \
-		-C link_args="-Wl,-soname,libcryptobox.so"
-	mkdir -p jni/arm64-v8a
-	cp build/src/$(CRYPTOBOX_NAME)/target/aarch64-linux-android/release/libcryptobox.so jni/arm64-v8a/libcryptobox.so
 
 jni/include/cbox.h: | build/src/$(CRYPTOBOX_NAME)
 	mkdir -p jni/include
@@ -148,17 +113,8 @@ include ../mk/libsodium-src.mk
 .PHONY: libsodium-armeabi-v7a
 libsodium-armeabi-v7a: jni/armeabi-v7a/libsodium.so
 
-.PHONY: libsodium-aarch64
-libsodium-aarch64: jni/arm64-v8a/libsodium.so
-
-.PHONY: libsodium-x86
-libsodium-x86: jni/x86/libsodium.so
-
-.PHONY: libsodium-x86_64
-libsodium-x86_64: jni/x86_64/libsodium.so
-
 .PHONY: libsodium
-libsodium: jni/armeabi-v7a/libsodium.so jni/arm64-v8a/libsodium.so jni/x86/libsodium.so jni/x86_64/libsodium.so
+libsodium: jni/armeabi-v7a/libsodium.sox
 
 jni/armeabi-v7a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	cd build/src/$(LIBSODIUM_NAME) && \
@@ -181,65 +137,3 @@ jni/armeabi-v7a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	mkdir -p jni/armeabi-v7a
 	cp build/libsodium-android-armv7-a/lib/libsodium.so jni/armeabi-v7a/
 
-jni/x86/libsodium.so: | build/src/$(LIBSODIUM_NAME)
-	cd build/src/$(LIBSODIUM_NAME) && \
-	export CFLAGS="-Os -march=i686" && \
-	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
-	export AR=${TOOLCHAIN}/bin/i686-linux-android-ar && \
-	export AS=${TOOLCHAIN}/bin/i686-linux-android-as && \
-	export CC=${TOOLCHAIN}/bin/i686-linux-android16-clang && \
-	export CXX=${TOOLCHAIN}/bin/i686-linux-android16-clang++ && \
-	export LD=${TOOLCHAIN}/bin/i686-linux-android-ld && \
-	export RANLIB=${TOOLCHAIN}/bin/i686-linux-android-ranlib && \
-	export STRIP=${TOOLCHAIN}/bin/i686-linux-android-strip && \
-	./configure --host=i686-linux-android \
-	            --with-sysroot="${TOOLCHAIN}/sysroot" \
-	            --prefix="$(CURDIR)/build/libsodium-android-x86" \
-	            --disable-soname-versions \
-	            && \
-	make clean && \
-	make -j3 && make install
-	mkdir -p jni/x86
-	cp build/libsodium-android-x86/lib/libsodium.so jni/x86/
-
-jni/x86_64/libsodium.so: | build/src/$(LIBSODIUM_NAME)
-	cd build/src/$(LIBSODIUM_NAME) && \
-	export CFLAGS="-Os -march=x86-64" && \
-	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
-	export AR=${TOOLCHAIN}/bin/x86_64-linux-android-ar && \
-	export AS=${TOOLCHAIN}/bin/x86_64-linux-android-as && \
-	export CC=${TOOLCHAIN}/bin/x86_64-linux-android21-clang && \
-	export CXX=${TOOLCHAIN}/bin/x86_64-linux-android21-clang++ && \
-	export LD=${TOOLCHAIN}/bin/x86_64-linux-android-ld && \
-	export RANLIB=${TOOLCHAIN}/bin/x86_64-linux-android-ranlib && \
-	export STRIP=${TOOLCHAIN}/bin/x86_64-linux-android-strip && \
-	./configure --host=x86_64-linux-android \
-	            --with-sysroot="${TOOLCHAIN}/sysroot" \
-	            --prefix="$(CURDIR)/build/libsodium-android-x86_64" \
-	            --disable-soname-versions \
-	            && \
-	make clean && \
-	make -j3 && make install
-	mkdir -p jni/x86_64
-	cp build/libsodium-android-x86_64/lib/libsodium.so jni/x86_64/
-
-jni/arm64-v8a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
-	cd build/src/$(LIBSODIUM_NAME) && \
-	export CFLAGS="-Os -march=armv8-a" && \
-	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
-	export AR=${TOOLCHAIN}/bin/aarch64-linux-android-ar && \
-	export AS=${TOOLCHAIN}/bin/aarch64-linux-android-as && \
-	export CC=${TOOLCHAIN}/bin/aarch64-linux-android21-clang && \
-	export CXX=${TOOLCHAIN}/bin/aarch64-linux-android21-clang++ && \
-	export LD=${TOOLCHAIN}/bin/aarch64-linux-android-ld && \
-	export RANLIB=${TOOLCHAIN}/bin/aarch64-linux-android-ranlib && \
-	export STRIP=${TOOLCHAIN}/bin/aarch64-linux-android-strip && \
-	./configure --host=aarch64-linux-android \
-	            --with-sysroot="${TOOLCHAIN}/sysroot" \
-	            --prefix="$(CURDIR)/build/libsodium-android-armv8-a" \
-	            --disable-soname-versions \
-	            && \
-	make clean && \
-	make -j3 && make install
-	mkdir -p jni/arm64-v8a
-	cp build/libsodium-android-armv8-a/lib/libsodium.so jni/arm64-v8a/

--- a/android/Makefile
+++ b/android/Makefile
@@ -1,9 +1,11 @@
 SHELL   := /usr/bin/env bash
 
-ANDROID_NDK_TOOLCHAIN_ARM     ?=
-ANDROID_NDK_TOOLCHAIN_X86     ?=
-ANDROID_NDK_TOOLCHAIN_X86_64  ?=
-ANDROID_NDK_TOOLCHAIN_AARCH64 ?=
+ANDROID_NDK_HOME              ?=
+
+OS       := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH     := $(shell uname -m)
+export HOST_TAG=${OS}-${ARCH}
+export TOOLCHAIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${HOST_TAG}"
 
 include ../mk/version.mk
 
@@ -157,14 +159,18 @@ include ../mk/libsodium-src.mk
 libsodium: jni/armeabi-v7a/libsodium.so jni/arm64-v8a/libsodium.so jni/x86/libsodium.so jni/x86_64/libsodium.so
 
 jni/armeabi-v7a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
-ifndef ANDROID_NDK_TOOLCHAIN_ARM
-$(error ANDROID_NDK_TOOLCHAIN_ARM is not set)
-endif
 	cd build/src/$(LIBSODIUM_NAME) && \
 	export CFLAGS="-Os -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -marm -march=armv7-a" && \
-	export PATH="${PATH}:${ANDROID_NDK_TOOLCHAIN_ARM}/bin:" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin:" && \
+	echo "toolchain: ${TOOLCHAIN}" && \
+	export AR=${TOOLCHAIN}/bin/arm-linux-androideabi-ar && \
+	export AS=${TOOLCHAIN}/bin/arm-linux-androideabi-as && \
+	export CC=${TOOLCHAIN}/bin/armv7a-linux-androideabi16-clang && \
+	export CXX=${TOOLCHAIN}/bin/armv7a-linux-androideabi16-clang++ && \
+	export LD=${TOOLCHAIN}/bin/arm-linux-androideabi-ld && \
+	export RANLIB=${TOOLCHAIN}/bin/arm-linux-androideabi-ranlib && \
+	export STRIP=${TOOLCHAIN}/bin/arm-linux-androideabi-strip && \
 	./configure --host=arm-linux-androideabi \
-	            --with-sysroot="$(ANDROID_NDK_TOOLCHAIN_ARM)/sysroot" \
 	            --prefix="$(CURDIR)/build/libsodium-android-armv7-a" \
 	            --disable-soname-versions \
 	            && \
@@ -174,14 +180,17 @@ endif
 	cp build/libsodium-android-armv7-a/lib/libsodium.so jni/armeabi-v7a/
 
 jni/x86/libsodium.so: | build/src/$(LIBSODIUM_NAME)
-ifndef ANDROID_NDK_TOOLCHAIN_X86
-$(error ANDROID_NDK_TOOLCHAIN_X86 is not set)
-endif
 	cd build/src/$(LIBSODIUM_NAME) && \
 	export CFLAGS="-Os -march=i686" && \
-	export PATH="${PATH}:${ANDROID_NDK_TOOLCHAIN_X86}/bin" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export AR=${TOOLCHAIN}/bin/i686-linux-android-ar && \
+	export AS=${TOOLCHAIN}/bin/i686-linux-android-as && \
+	export CC=${TOOLCHAIN}/bin/i686-linux-android21-clang && \
+	export CXX=${TOOLCHAIN}/bin/i686-linux-android21-clang++ && \
+	export LD=${TOOLCHAIN}/bin/i686-linux-android-ld && \
+	export RANLIB=${TOOLCHAIN}/bin/i686-linux-android-ranlib && \
+	export STRIP=${TOOLCHAIN}/bin/i686-linux-android-strip && \
 	./configure --host=i686-linux-android \
-	            --with-sysroot="$(ANDROID_NDK_TOOLCHAIN_X86)/sysroot" \
 	            --prefix="$(CURDIR)/build/libsodium-android-x86" \
 	            --disable-soname-versions \
 	            && \
@@ -191,14 +200,17 @@ endif
 	cp build/libsodium-android-x86/lib/libsodium.so jni/x86/
 
 jni/x86_64/libsodium.so: | build/src/$(LIBSODIUM_NAME)
-ifndef ANDROID_NDK_TOOLCHAIN_X86_64
-$(error ANDROID_NDK_TOOLCHAIN_X86_64 is not set)
-endif
 	cd build/src/$(LIBSODIUM_NAME) && \
 	export CFLAGS="-Os -march=x86-64" && \
-	export PATH="${PATH}:${ANDROID_NDK_TOOLCHAIN_X86_64}/bin" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export AR=${TOOLCHAIN}/bin/x86_64-linux-android-ar && \
+	export AS=${TOOLCHAIN}/bin/x86_64-linux-android-as && \
+	export CC=${TOOLCHAIN}/bin/x86_64-linux-android21-clang && \
+	export CXX=${TOOLCHAIN}/bin/x86_64-linux-android21-clang++ && \
+	export LD=${TOOLCHAIN}/bin/x86_64-linux-android-ld && \
+	export RANLIB=${TOOLCHAIN}/bin/x86_64-linux-android-ranlib && \
+	export STRIP=${TOOLCHAIN}/bin/x86_64-linux-android-strip && \
 	./configure --host=x86_64-linux-android \
-	            --with-sysroot="$(ANDROID_NDK_TOOLCHAIN_X86_64)/sysroot" \
 	            --prefix="$(CURDIR)/build/libsodium-android-x86_64" \
 	            --disable-soname-versions \
 	            && \
@@ -208,14 +220,17 @@ endif
 	cp build/libsodium-android-x86_64/lib/libsodium.so jni/x86_64/
 
 jni/arm64-v8a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
-ifndef ANDROID_NDK_TOOLCHAIN_AARCH64
-$(error ANDROID_NDK_TOOLCHAIN_AARCH64 is not set)
-endif
 	cd build/src/$(LIBSODIUM_NAME) && \
 	export CFLAGS="-Os -march=armv8-a" && \
-	export PATH="${PATH}:${ANDROID_NDK_TOOLCHAIN_AARCH64}/bin" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export AR=${TOOLCHAIN}/bin/aarch64-linux-android-ar && \
+	export AS=${TOOLCHAIN}/bin/aarch64-linux-android-as && \
+	export CC=${TOOLCHAIN}/bin/aarch64-linux-android21-clang && \
+	export CXX=${TOOLCHAIN}/bin/aarch64-linux-android21-clang++ && \
+	export LD=${TOOLCHAIN}/bin/aarch64-linux-android-ld && \
+	export RANLIB=${TOOLCHAIN}/bin/aarch64-linux-android-ranlib && \
+	export STRIP=${TOOLCHAIN}/bin/aarch64-linux-android-strip && \
 	./configure --host=aarch64-linux-android \
-	            --with-sysroot="$(ANDROID_NDK_TOOLCHAIN_AARCH64)/sysroot" \
 	            --prefix="$(CURDIR)/build/libsodium-android-armv8-a" \
 	            --disable-soname-versions \
 	            && \

--- a/android/Makefile
+++ b/android/Makefile
@@ -115,8 +115,6 @@ jni/x86/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 jni/x86_64/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
-	echo "\nEnvironment\n:" && \
-	echo `env` && \
 	cargo rustc -v --lib --release --target=x86_64-linux-android -- \
 		-L ../../libsodium-android-x86_64/lib \
 		-l sodium \

--- a/android/Makefile
+++ b/android/Makefile
@@ -90,6 +90,7 @@ jni/armeabi-v7a/libcryptobox.so: libsodium-armeabi-v7a | build/src/$(CRYPTOBOX_N
 	export SODIUM_LIB_DIR=../../libsodium-android-armv7-a/lib && \
 	export SODIUM_SHARED=1 && \
 	cargo rustc --lib --release --target=armv7-linux-androideabi -- \
+		-L ../../libsodium-android-arm-v7a/lib \
 		-C ar=arm-linux-androideabi-ar \
 		-C linker=armv7a-linux-androideabi16-clang 
 	mkdir -p jni/armeabi-v7a
@@ -101,6 +102,7 @@ jni/x86/libcryptobox.so: libsodium-x86 | build/src/$(CRYPTOBOX_NAME)
 	export SODIUM_LIB_DIR=../../libsodium-x86/lib && \
 	export SODIUM_SHARED=1 && \
 	cargo rustc --lib --release --target=i686-linux-android -- \
+		-L ../../libsodium-android-x86/lib \
 		-C ar=i686-linux-android-ar \
 		-C linker=i686-linux-android16-clang
 	mkdir -p jni/x86
@@ -112,17 +114,19 @@ jni/x86_64/libcryptobox.so: libsodium-x86_64 | build/src/$(CRYPTOBOX_NAME)
 	export SODIUM_LIB_DIR=../../libsodium-x86_64/lib && \
 	export SODIUM_SHARED=1 && \
 	cargo rustc -v --lib --release --target=x86_64-linux-android -- \
+		-L ../../libsodium-android-x86_64/lib \
 		-C ar=x86_64-linux-android-ar \
 		-C linker=x86_64-linux-android21-clang
 	mkdir -p jni/x86_64
 	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-linux-android/release/libcryptobox.so jni/x86_64/libcryptobox.so
 
-jni/arm64-v8a/libcryptobox.so: libsodium-arm64-v8a | build/src/$(CRYPTOBOX_NAME)
+jni/arm64-v8a/libcryptobox.so: libsodium-aarch64 | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
 	export SODIUM_LIB_DIR=../../libsodium-arm64-v8a/lib && \
 	export SODIUM_SHARED=1 && \
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc --lib --release --target=aarch64-linux-android -- \
+		-L ../../libsodium-android-armv8-a/lib \
 		-C ar=aarch64-linux-android-ar \
 		-C linker=aarch64-linux-android21-clang
 	mkdir -p jni/arm64-v8a
@@ -235,4 +239,4 @@ jni/arm64-v8a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	make clean && \
 	make -j3 && make install
 	mkdir -p jni/arm64-v8a
-	c
+	cp build/libsodium-android-armv8-a/lib/libsodium.so jni/arm64-v8a

--- a/android/Makefile
+++ b/android/Makefile
@@ -117,14 +117,14 @@ jni/x86_64/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	echo "\nEnvironment\n:" && \
 	echo `env` && \
-	cargo rustc -v --lib --release --target=x86_64-unknown-linux-gnu -- \
+	cargo rustc -v --lib --release --target=x86_64-linux-android -- \
 		-L ../../libsodium-android-x86_64/lib \
 		-l sodium \
 		-C ar=x86_64-linux-android-ar \
 		-C linker=x86_64-linux-android21-clang \
 		-C link_args="-Wl,-soname,libcryptobox.so"
 	mkdir -p jni/x86_64
-	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-unknown-linux-gnu/release/libcryptobox.so jni/x86_64/libcryptobox.so
+	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-linux-android/release/libcryptobox.so jni/x86_64/libcryptobox.so
 
 jni/arm64-v8a/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \

--- a/android/Makefile
+++ b/android/Makefile
@@ -13,10 +13,6 @@ include ../mk/version.mk
 # cf. https://github.com/alexcrichton/pkg-config-rs/blob/master/src/lib.rs#L12
 export PKG_CONFIG_ALLOW_CROSS=1
 
-# Hint for sodiumoxide to find the precompiled libsodium library
-# See the README at  https://github.com/sodiumoxide/sodiumoxide
-export SODIUM_LIB_DIR="./libs"
-
 .PHONY: all
 all: compile
 
@@ -86,7 +82,7 @@ dist: compile dist-tar dist-aar
 include ../mk/cryptobox-src.mk
 
 .PHONY: cryptobox
-cryptobox: jni/armeabi-v7a/libcryptobox.so jni/include/cbox.h
+cryptobox: jni/armeabi-v7a/libcryptobox.so jni/x86/libcryptobox.so jni/x86_64/libcryptobox.so jni/arm64-v8a/libcryptobox.so jni/include/cbox.h
 
 jni/armeabi-v7a/libcryptobox.so: libsodium-armeabi-v7a | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
@@ -94,11 +90,43 @@ jni/armeabi-v7a/libcryptobox.so: libsodium-armeabi-v7a | build/src/$(CRYPTOBOX_N
 	export SODIUM_LIB_DIR=../../libsodium-android-armv7-a/lib && \
 	export SODIUM_SHARED=1 && \
 	cargo rustc --lib --release --target=armv7-linux-androideabi -- \
-	               -C ar=arm-linux-androideabi-ar \
-	               -C linker=armv7a-linux-androideabi16-clang 
+		-C ar=arm-linux-androideabi-ar \
+		-C linker=armv7a-linux-androideabi16-clang 
 	mkdir -p jni/armeabi-v7a
 	cp build/src/$(CRYPTOBOX_NAME)/target/armv7-linux-androideabi/release/libcryptobox.so jni/armeabi-v7a/libcryptobox.so
 
+jni/x86/libcryptobox.so: libsodium-x86 | build/src/$(CRYPTOBOX_NAME)
+	cd build/src/$(CRYPTOBOX_NAME) && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export SODIUM_LIB_DIR=../../libsodium-x86/lib && \
+	export SODIUM_SHARED=1 && \
+	cargo rustc --lib --release --target=i686-linux-android -- \
+		-C ar=i686-linux-android-ar \
+		-C linker=i686-linux-android16-clang
+	mkdir -p jni/x86
+	cp build/src/$(CRYPTOBOX_NAME)/target/i686-linux-android/release/libcryptobox.so jni/x86/libcryptobox.so
+
+jni/x86_64/libcryptobox.so: libsodium-x86_64 | build/src/$(CRYPTOBOX_NAME)
+	cd build/src/$(CRYPTOBOX_NAME) && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export SODIUM_LIB_DIR=../../libsodium-x86_64/lib && \
+	export SODIUM_SHARED=1 && \
+	cargo rustc -v --lib --release --target=x86_64-linux-android -- \
+		-C ar=x86_64-linux-android-ar \
+		-C linker=x86_64-linux-android21-clang
+	mkdir -p jni/x86_64
+	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-linux-android/release/libcryptobox.so jni/x86_64/libcryptobox.so
+
+jni/arm64-v8a/libcryptobox.so: libsodium-arm64-v8a | build/src/$(CRYPTOBOX_NAME)
+	cd build/src/$(CRYPTOBOX_NAME) && \
+	export SODIUM_LIB_DIR=../../libsodium-arm64-v8a/lib && \
+	export SODIUM_SHARED=1 && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	cargo rustc --lib --release --target=aarch64-linux-android -- \
+		-C ar=aarch64-linux-android-ar \
+		-C linker=aarch64-linux-android21-clang
+	mkdir -p jni/arm64-v8a
+	cp build/src/$(CRYPTOBOX_NAME)/target/aarch64-linux-android/release/libcryptobox.so jni/arm64-v8a/libcryptobox.so
 
 
 jni/include/cbox.h: | build/src/$(CRYPTOBOX_NAME)
@@ -113,8 +141,17 @@ include ../mk/libsodium-src.mk
 .PHONY: libsodium-armeabi-v7a
 libsodium-armeabi-v7a: jni/armeabi-v7a/libsodium.so
 
+.PHONY: libsodium-aarch64
+libsodium-aarch64: jni/arm64-v8a/libsodium.so
+
+.PHONY: libsodium-x86
+libsodium-x86: jni/x86/libsodium.so
+
+.PHONY: libsodium-x86_64
+libsodium-x86_64: jni/x86_64/libsodium.so
+
 .PHONY: libsodium
-libsodium: jni/armeabi-v7a/libsodium.sox
+libsodium: jni/armeabi-v7a/libsodium.so jni/arm64-v8a/libsodium.so jni/x86/libsodium.so jni/x86_64/libsodium.so
 
 jni/armeabi-v7a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	cd build/src/$(LIBSODIUM_NAME) && \
@@ -137,3 +174,65 @@ jni/armeabi-v7a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	mkdir -p jni/armeabi-v7a
 	cp build/libsodium-android-armv7-a/lib/libsodium.so jni/armeabi-v7a/
 
+jni/x86/libsodium.so: | build/src/$(LIBSODIUM_NAME)
+	cd build/src/$(LIBSODIUM_NAME) && \
+	export CFLAGS="-Os -march=i686" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export AR=${TOOLCHAIN}/bin/i686-linux-android-ar && \
+	export AS=${TOOLCHAIN}/bin/i686-linux-android-as && \
+	export CC=${TOOLCHAIN}/bin/i686-linux-android16-clang && \
+	export CXX=${TOOLCHAIN}/bin/i686-linux-android16-clang++ && \
+	export LD=${TOOLCHAIN}/bin/i686-linux-android-ld && \
+	export RANLIB=${TOOLCHAIN}/bin/i686-linux-android-ranlib && \
+	export STRIP=${TOOLCHAIN}/bin/i686-linux-android-strip && \
+	./configure --host=i686-linux-android \
+	            --with-sysroot="${TOOLCHAIN}/sysroot" \
+	            --prefix="$(CURDIR)/build/libsodium-android-x86" \
+	            --disable-soname-versions \
+	            && \
+	make clean && \
+	make -j3 && make install
+	mkdir -p jni/x86
+	cp build/libsodium-android-x86/lib/libsodium.so jni/x86/
+
+jni/x86_64/libsodium.so: | build/src/$(LIBSODIUM_NAME)
+	cd build/src/$(LIBSODIUM_NAME) && \
+	export CFLAGS="-Os -march=x86-64" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export AR=${TOOLCHAIN}/bin/x86_64-linux-android-ar && \
+	export AS=${TOOLCHAIN}/bin/x86_64-linux-android-as && \
+	export CC=${TOOLCHAIN}/bin/x86_64-linux-android21-clang && \
+	export CXX=${TOOLCHAIN}/bin/x86_64-linux-android21-clang++ && \
+	export LD=${TOOLCHAIN}/bin/x86_64-linux-android-ld && \
+	export RANLIB=${TOOLCHAIN}/bin/x86_64-linux-android-ranlib && \
+	export STRIP=${TOOLCHAIN}/bin/x86_64-linux-android-strip && \
+	./configure --host=x86_64-linux-android \
+	            --with-sysroot="${TOOLCHAIN}/sysroot" \
+	            --prefix="$(CURDIR)/build/libsodium-android-x86_64" \
+	            --disable-soname-versions \
+	            && \
+	make clean && \
+	make -j3 && make install
+	mkdir -p jni/x86_64
+	cp build/libsodium-android-x86_64/lib/libsodium.so jni/x86_64/
+
+jni/arm64-v8a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
+	cd build/src/$(LIBSODIUM_NAME) && \
+	export CFLAGS="-Os -march=armv8-a" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
+	export AR=${TOOLCHAIN}/bin/aarch64-linux-android-ar && \
+	export AS=${TOOLCHAIN}/bin/aarch64-linux-android-as && \
+	export CC=${TOOLCHAIN}/bin/aarch64-linux-android21-clang && \
+	export CXX=${TOOLCHAIN}/bin/aarch64-linux-android21-clang++ && \
+	export LD=${TOOLCHAIN}/bin/aarch64-linux-android-ld && \
+	export RANLIB=${TOOLCHAIN}/bin/aarch64-linux-android-ranlib && \
+	export STRIP=${TOOLCHAIN}/bin/aarch64-linux-android-strip && \
+	./configure --host=aarch64-linux-android \
+	            --with-sysroot="${TOOLCHAIN}/sysroot" \
+	            --prefix="$(CURDIR)/build/libsodium-android-armv8-a" \
+	            --disable-soname-versions \
+	            && \
+	make clean && \
+	make -j3 && make install
+	mkdir -p jni/arm64-v8a
+	c

--- a/android/Makefile
+++ b/android/Makefile
@@ -88,7 +88,7 @@ include ../mk/cryptobox-src.mk
 .PHONY: cryptobox
 cryptobox: jni/armeabi-v7a/libcryptobox.so jni/x86/libcryptobox.so jni/x86_64/libcryptobox.so jni/arm64-v8a/libcryptobox.so jni/include/cbox.h
 
-jni/armeabi-v7a/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
+jni/armeabi-v7a/libcryptobox.so: libsodium-armeabi-v7a | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc --lib --release --target=armv7-linux-androideabi -- \
@@ -100,7 +100,7 @@ jni/armeabi-v7a/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 	mkdir -p jni/armeabi-v7a
 	cp build/src/$(CRYPTOBOX_NAME)/target/armv7-linux-androideabi/release/libcryptobox.so jni/armeabi-v7a/libcryptobox.so
 
-jni/x86/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
+jni/x86/libcryptobox.so: libsodium-x86 | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc --lib --release --target=i686-linux-android -- \
@@ -112,7 +112,7 @@ jni/x86/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 	mkdir -p jni/x86
 	cp build/src/$(CRYPTOBOX_NAME)/target/i686-linux-android/release/libcryptobox.so jni/x86/libcryptobox.so
 
-jni/x86_64/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
+jni/x86_64/libcryptobox.so: libsodium-x86_64 | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc -v --lib --release --target=x86_64-linux-android -- \
@@ -124,7 +124,7 @@ jni/x86_64/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 	mkdir -p jni/x86_64
 	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-linux-android/release/libcryptobox.so jni/x86_64/libcryptobox.so
 
-jni/arm64-v8a/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
+jni/arm64-v8a/libcryptobox.so: libsodium-arm64-v8a | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc --lib --release --target=aarch64-linux-android -- \
@@ -144,6 +144,18 @@ jni/include/cbox.h: | build/src/$(CRYPTOBOX_NAME)
 # libsodium
 
 include ../mk/libsodium-src.mk
+
+.PHONY: libsodium-armeabi-v7a
+libsodium-armeabi-v7a: jni/armeabi-v7a/libsodium.so
+
+.PHONY: libsodium-aarch64
+libsodium-aarch64: jni/arm64-v8a/libsodium.so
+
+.PHONY: libsodium-x86
+libsodium-x86: jni/x86/libsodium.so
+
+.PHONY: libsodium-x86_64
+libsodium-x86_64: jni/x86_64/libsodium.so
 
 .PHONY: libsodium
 libsodium: jni/armeabi-v7a/libsodium.so jni/arm64-v8a/libsodium.so jni/x86/libsodium.so jni/x86_64/libsodium.so

--- a/android/Makefile
+++ b/android/Makefile
@@ -129,7 +129,7 @@ jni/arm64-v8a/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 		-L ../../libsodium-android-armv8-a/lib \
 		-l sodium \
 		-C ar=aarch64-linux-android-ar \
-		-C linker=aarch64-linux-android16-clang \
+		-C linker=aarch64-linux-android21-clang \
 		-C link_args="-Wl,-soname,libcryptobox.so"
 	mkdir -p jni/arm64-v8a
 	cp build/src/$(CRYPTOBOX_NAME)/target/aarch64-linux-android/release/libcryptobox.so jni/arm64-v8a/libcryptobox.so
@@ -192,8 +192,8 @@ jni/x86_64/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	export AR=${TOOLCHAIN}/bin/x86_64-linux-android-ar && \
 	export AS=${TOOLCHAIN}/bin/x86_64-linux-android-as && \
-	export CC=${TOOLCHAIN}/bin/x86_64-linux-android16-clang && \
-	export CXX=${TOOLCHAIN}/bin/x86_64-linux-android16-clang++ && \
+	export CC=${TOOLCHAIN}/bin/x86_64-linux-android21-clang && \
+	export CXX=${TOOLCHAIN}/bin/x86_64-linux-android21-clang++ && \
 	export LD=${TOOLCHAIN}/bin/x86_64-linux-android-ld && \
 	export RANLIB=${TOOLCHAIN}/bin/x86_64-linux-android-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/x86_64-linux-android-strip && \
@@ -212,8 +212,8 @@ jni/arm64-v8a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	export AR=${TOOLCHAIN}/bin/aarch64-linux-android-ar && \
 	export AS=${TOOLCHAIN}/bin/aarch64-linux-android-as && \
-	export CC=${TOOLCHAIN}/bin/aarch64-linux-android16-clang && \
-	export CXX=${TOOLCHAIN}/bin/aarch64-linux-android16-clang++ && \
+	export CC=${TOOLCHAIN}/bin/aarch64-linux-android21-clang && \
+	export CXX=${TOOLCHAIN}/bin/aarch64-linux-android21-clang++ && \
 	export LD=${TOOLCHAIN}/bin/aarch64-linux-android-ld && \
 	export RANLIB=${TOOLCHAIN}/bin/aarch64-linux-android-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/aarch64-linux-android-strip && \

--- a/android/Makefile
+++ b/android/Makefile
@@ -89,41 +89,32 @@ include ../mk/cryptobox-src.mk
 cryptobox: jni/armeabi-v7a/libcryptobox.so jni/x86/libcryptobox.so jni/x86_64/libcryptobox.so jni/arm64-v8a/libcryptobox.so jni/include/cbox.h
 
 jni/armeabi-v7a/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
-ifndef ANDROID_NDK_TOOLCHAIN_ARM
-$(error ANDROID_NDK_TOOLCHAIN_ARM is not set)
-endif
 	cd build/src/$(CRYPTOBOX_NAME) && \
-	export PATH="${PATH}:${ANDROID_NDK_TOOLCHAIN_ARM}/bin" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc --lib --release --target=armv7-linux-androideabi -- \
 		-L ../../libsodium-android-armv7-a/lib \
 		-l sodium \
 		-C ar=arm-linux-androideabi-ar \
-		-C linker=arm-linux-androideabi-gcc \
+		-C linker=armv7a-linux-androideabi16-clang \
 		-C link_args="-Wl,-soname,libcryptobox.so"
 	mkdir -p jni/armeabi-v7a
 	cp build/src/$(CRYPTOBOX_NAME)/target/armv7-linux-androideabi/release/libcryptobox.so jni/armeabi-v7a/libcryptobox.so
 
 jni/x86/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
-ifndef ANDROID_NDK_TOOLCHAIN_X86
-$(error ANDROID_NDK_TOOLCHAIN_X86 is not set)
-endif
 	cd build/src/$(CRYPTOBOX_NAME) && \
-	export PATH="${PATH}:${ANDROID_NDK_TOOLCHAIN_X86}/bin" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc --lib --release --target=i686-linux-android -- \
 		-L ../../libsodium-android-x86/lib \
 		-l sodium \
 		-C ar=i686-linux-android-ar \
-		-C linker=i686-linux-android-gcc \
+		-C linker=i686-linux-android16-clang \
 		-C link_args="-Wl,-soname,libcryptobox.so"
 	mkdir -p jni/x86
 	cp build/src/$(CRYPTOBOX_NAME)/target/i686-linux-android/release/libcryptobox.so jni/x86/libcryptobox.so
 
 jni/x86_64/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
-ifndef ANDROID_NDK_TOOLCHAIN_X86_64
-$(error ANDROID_NDK_TOOLCHAIN_X86_64 is not set)
-endif
 	cd build/src/$(CRYPTOBOX_NAME) && \
-	export PATH="${PATH}:${ANDROID_NDK_TOOLCHAIN_X86_64}/bin" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc --lib --release --target=x86_64-unknown-linux-gnu -- \
 		-L ../../libsodium-android-x86_64/lib \
 		-l sodium \
@@ -132,16 +123,13 @@ endif
 	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-unknown-linux-gnu/release/libcryptobox.so jni/x86_64/libcryptobox.so
 
 jni/arm64-v8a/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
-ifndef ANDROID_NDK_TOOLCHAIN_AARCH64
-$(error ANDROID_NDK_TOOLCHAIN_AARCH64 is not set)
-endif
 	cd build/src/$(CRYPTOBOX_NAME) && \
-	export PATH="${PATH}:${ANDROID_NDK_TOOLCHAIN_AARCH64}/bin" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	cargo rustc --lib --release --target=aarch64-linux-android -- \
 		-L ../../libsodium-android-armv8-a/lib \
 		-l sodium \
 		-C ar=aarch64-linux-android-ar \
-		-C linker=aarch64-linux-android-gcc \
+		-C linker=aarch64-linux-android16-clang \
 		-C link_args="-Wl,-soname,libcryptobox.so"
 	mkdir -p jni/arm64-v8a
 	cp build/src/$(CRYPTOBOX_NAME)/target/aarch64-linux-android/release/libcryptobox.so jni/arm64-v8a/libcryptobox.so
@@ -161,8 +149,7 @@ libsodium: jni/armeabi-v7a/libsodium.so jni/arm64-v8a/libsodium.so jni/x86/libso
 jni/armeabi-v7a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	cd build/src/$(LIBSODIUM_NAME) && \
 	export CFLAGS="-Os -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -marm -march=armv7-a" && \
-	export PATH="${PATH}:${TOOLCHAIN}/bin:" && \
-	echo "toolchain: ${TOOLCHAIN}" && \
+	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	export AR=${TOOLCHAIN}/bin/arm-linux-androideabi-ar && \
 	export AS=${TOOLCHAIN}/bin/arm-linux-androideabi-as && \
 	export CC=${TOOLCHAIN}/bin/armv7a-linux-androideabi16-clang && \
@@ -185,8 +172,8 @@ jni/x86/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	export AR=${TOOLCHAIN}/bin/i686-linux-android-ar && \
 	export AS=${TOOLCHAIN}/bin/i686-linux-android-as && \
-	export CC=${TOOLCHAIN}/bin/i686-linux-android21-clang && \
-	export CXX=${TOOLCHAIN}/bin/i686-linux-android21-clang++ && \
+	export CC=${TOOLCHAIN}/bin/i686-linux-android16-clang && \
+	export CXX=${TOOLCHAIN}/bin/i686-linux-android16-clang++ && \
 	export LD=${TOOLCHAIN}/bin/i686-linux-android-ld && \
 	export RANLIB=${TOOLCHAIN}/bin/i686-linux-android-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/i686-linux-android-strip && \
@@ -205,8 +192,8 @@ jni/x86_64/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	export AR=${TOOLCHAIN}/bin/x86_64-linux-android-ar && \
 	export AS=${TOOLCHAIN}/bin/x86_64-linux-android-as && \
-	export CC=${TOOLCHAIN}/bin/x86_64-linux-android21-clang && \
-	export CXX=${TOOLCHAIN}/bin/x86_64-linux-android21-clang++ && \
+	export CC=${TOOLCHAIN}/bin/x86_64-linux-android16-clang && \
+	export CXX=${TOOLCHAIN}/bin/x86_64-linux-android16-clang++ && \
 	export LD=${TOOLCHAIN}/bin/x86_64-linux-android-ld && \
 	export RANLIB=${TOOLCHAIN}/bin/x86_64-linux-android-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/x86_64-linux-android-strip && \
@@ -225,8 +212,8 @@ jni/arm64-v8a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
 	export AR=${TOOLCHAIN}/bin/aarch64-linux-android-ar && \
 	export AS=${TOOLCHAIN}/bin/aarch64-linux-android-as && \
-	export CC=${TOOLCHAIN}/bin/aarch64-linux-android21-clang && \
-	export CXX=${TOOLCHAIN}/bin/aarch64-linux-android21-clang++ && \
+	export CC=${TOOLCHAIN}/bin/aarch64-linux-android16-clang && \
+	export CXX=${TOOLCHAIN}/bin/aarch64-linux-android16-clang++ && \
 	export LD=${TOOLCHAIN}/bin/aarch64-linux-android-ld && \
 	export RANLIB=${TOOLCHAIN}/bin/aarch64-linux-android-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/aarch64-linux-android-strip && \

--- a/android/Makefile
+++ b/android/Makefile
@@ -115,9 +115,13 @@ jni/x86/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 jni/x86_64/libcryptobox.so: libsodium | build/src/$(CRYPTOBOX_NAME)
 	cd build/src/$(CRYPTOBOX_NAME) && \
 	export PATH="${PATH}:${TOOLCHAIN}/bin" && \
-	cargo rustc --lib --release --target=x86_64-unknown-linux-gnu -- \
+	echo "\nEnvironment\n:" && \
+	echo `env` && \
+	cargo rustc -v --lib --release --target=x86_64-unknown-linux-gnu -- \
 		-L ../../libsodium-android-x86_64/lib \
 		-l sodium \
+		-C ar=x86_64-linux-android-ar \
+		-C linker=x86_64-linux-android21-clang \
 		-C link_args="-Wl,-soname,libcryptobox.so"
 	mkdir -p jni/x86_64
 	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-unknown-linux-gnu/release/libcryptobox.so jni/x86_64/libcryptobox.so
@@ -158,6 +162,7 @@ jni/armeabi-v7a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export RANLIB=${TOOLCHAIN}/bin/arm-linux-androideabi-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/arm-linux-androideabi-strip && \
 	./configure --host=arm-linux-androideabi \
+	            --with-sysroot="${TOOLCHAIN}/sysroot" \
 	            --prefix="$(CURDIR)/build/libsodium-android-armv7-a" \
 	            --disable-soname-versions \
 	            && \
@@ -178,6 +183,7 @@ jni/x86/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export RANLIB=${TOOLCHAIN}/bin/i686-linux-android-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/i686-linux-android-strip && \
 	./configure --host=i686-linux-android \
+	            --with-sysroot="${TOOLCHAIN}/sysroot" \
 	            --prefix="$(CURDIR)/build/libsodium-android-x86" \
 	            --disable-soname-versions \
 	            && \
@@ -198,6 +204,7 @@ jni/x86_64/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export RANLIB=${TOOLCHAIN}/bin/x86_64-linux-android-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/x86_64-linux-android-strip && \
 	./configure --host=x86_64-linux-android \
+	            --with-sysroot="${TOOLCHAIN}/sysroot" \
 	            --prefix="$(CURDIR)/build/libsodium-android-x86_64" \
 	            --disable-soname-versions \
 	            && \
@@ -218,6 +225,7 @@ jni/arm64-v8a/libsodium.so: | build/src/$(LIBSODIUM_NAME)
 	export RANLIB=${TOOLCHAIN}/bin/aarch64-linux-android-ranlib && \
 	export STRIP=${TOOLCHAIN}/bin/aarch64-linux-android-strip && \
 	./configure --host=aarch64-linux-android \
+	            --with-sysroot="${TOOLCHAIN}/sysroot" \
 	            --prefix="$(CURDIR)/build/libsodium-android-armv8-a" \
 	            --disable-soname-versions \
 	            && \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 if [[ "$1" = "--clean" ]]; then
 	# clean stopped containers
@@ -8,5 +9,14 @@ if [[ "$1" = "--clean" ]]; then
 	docker rmi `docker images --filter "dangling=true" -q`
 fi
 
+IMAGE_NAME="wire/cryptobox-jni"
+
 # build
-docker build -t wire/cryptobox-jni .
+docker build -t ${IMAGE_NAME} .
+docker create -ti --name temp_build ${IMAGE_NAME} bash
+
+# archive
+rm -fr output || true
+mkdir -p output
+docker cp temp_build:/home/rust/cryptobox-jni/android/dist output/
+echo "DONE: output is in `pwd`/output"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "$1" = "clean" ]]; then
+if [[ "$1" = "--clean" ]]; then
 	# clean stopped containers
 	docker rm `docker ps -aq`
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ "$1" = "clean" ]]; then
+	# clean stopped containers
+	docker rm `docker ps -aq`
+
+	# clean dangling images
+	docker rmi `docker images --filter "dangling=true" -q`
+fi
+
+# build
+docker build -t wire/cryptobox-jni .

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$1" = "--clean" ]]; then
 	# clean stopped containers

--- a/docker-shell.sh
+++ b/docker-shell.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -it --rm -v $(pwd):/root wire/cryptobox-jni
+docker run --security-opt seccomp:unconfined -it --rm -v $(pwd):/root wire/cryptobox-jni

--- a/docker-shell.sh
+++ b/docker-shell.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-docker run --security-opt seccomp:unconfined -it --rm -v $(pwd):/root wire/cryptobox-jni
+docker run --security-opt seccomp:unconfined -it --rm wire/cryptobox-jni

--- a/docker-shell.sh
+++ b/docker-shell.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -it --rm -v $(pwd):/root wire/cryptobox-jni

--- a/mk/cryptobox-src.mk
+++ b/mk/cryptobox-src.mk
@@ -1,4 +1,4 @@
-CRYPTOBOX_VERSION := v1.1.1
+CRYPTOBOX_VERSION := v1.1.0
 CRYPTOBOX_NAME    := cryptobox-$(CRYPTOBOX_VERSION)
 CRYPTOBOX_GIT_URL := https://github.com/wireapp/cryptobox-c.git
 

--- a/mk/cryptobox-src.mk
+++ b/mk/cryptobox-src.mk
@@ -7,4 +7,4 @@ build/src/$(CRYPTOBOX_NAME):
 	cd build/src && \
 	git clone $(CRYPTOBOX_GIT_URL) $(CRYPTOBOX_NAME) && \
 	cd $(CRYPTOBOX_NAME) && \
-	git checkout $(CRYPTOBOX_VERSION)
+	git checkout test_bumping_libs

--- a/mk/cryptobox-src.mk
+++ b/mk/cryptobox-src.mk
@@ -1,4 +1,4 @@
-CRYPTOBOX_VERSION := v1.1.0
+CRYPTOBOX_VERSION := v1.1.2
 CRYPTOBOX_NAME    := cryptobox-$(CRYPTOBOX_VERSION)
 CRYPTOBOX_GIT_URL := https://github.com/wireapp/cryptobox-c.git
 
@@ -7,4 +7,4 @@ build/src/$(CRYPTOBOX_NAME):
 	cd build/src && \
 	git clone $(CRYPTOBOX_GIT_URL) $(CRYPTOBOX_NAME) && \
 	cd $(CRYPTOBOX_NAME) && \
-	git checkout test_bumping_libs
+	git checkout $(CRYPTOBOX_VERSION)

--- a/mk/cryptobox-src.mk
+++ b/mk/cryptobox-src.mk
@@ -1,4 +1,4 @@
-CRYPTOBOX_VERSION := v1.1.0
+CRYPTOBOX_VERSION := v1.1.1
 CRYPTOBOX_NAME    := cryptobox-$(CRYPTOBOX_VERSION)
 CRYPTOBOX_GIT_URL := https://github.com/wireapp/cryptobox-c.git
 

--- a/mk/libsodium-src.mk
+++ b/mk/libsodium-src.mk
@@ -1,4 +1,4 @@
-LIBSODIUM_VERSION := 1.0.17
+LIBSODIUM_VERSION := 1.0.18
 LIBSODIUM_NAME    := libsodium-$(LIBSODIUM_VERSION)
 LIBSODIUM_URL     := http://download.libsodium.org/libsodium/releases/$(LIBSODIUM_NAME).tar.gz
 

--- a/mk/libsodium-src.mk
+++ b/mk/libsodium-src.mk
@@ -1,4 +1,4 @@
-LIBSODIUM_VERSION := 1.0.18
+LIBSODIUM_VERSION := 1.0.17
 LIBSODIUM_NAME    := libsodium-$(LIBSODIUM_VERSION)
 LIBSODIUM_URL     := http://download.libsodium.org/libsodium/releases/$(LIBSODIUM_NAME).tar.gz
 

--- a/mk/version.mk
+++ b/mk/version.mk
@@ -1,1 +1,1 @@
-VERSION := 1.1.0
+VERSION := 1.1.1


### PR DESCRIPTION
This PR moves the android build system to use the newer, default NDK installation.

The old method of generating custom standalone toolchains is deprecated since r19 of the Android NDK, so this PR simplifies building and removes the need for custom env vars.