### PR TITLE
Generate sources and javadoc artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ build/
 dist/
 output/
 local.properties
+*DS_Store*
+*.idea*
+*.iml
+android/.gradle
+android/*.aar
+android/*.pom
+android/*.gz
+android/*.iml
+android/*.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ USER root
 ENV PATH $PATH:/usr/local/sbin:/usr/sbin:/sbin
 
 ####### BASE TOOLS #######
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -qqy --no-install-recommends \
+RUN apt update
+RUN apt upgrade -y
+RUN apt install -qqy --no-install-recommends \
 	git \
 	wget \
 	build-essential \
@@ -21,11 +21,11 @@ RUN apt-get install -qqy --no-install-recommends \
 	less \
 	g++-multilib \
 	libc6-dev-i386 \
-	sudo \
-	openjdk-8-jdk-headless \
-	openjdk-8-jre-headless
-	
-ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+	sudo
+
+RUN apt install -qqy --no-install-recommends openjdk-11-jre-headless openjdk-11-jdk-headless
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
 ######## ANDROID #########
 

--- a/TEMPLATE.pom
+++ b/TEMPLATE.pom
@@ -3,10 +3,18 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wire</groupId>
     <artifactId>cryptobox-android</artifactId>
-    <packaging>aar</packaging>
     <description>cryptobox-android</description>
     <version>%%VERSION%%</version>
 	<packaging>aar</packaging>
+	<url>https://github.com/wireapp/cryptobox-jni</url>
+
+	<scm>
+        <connection>scm:git:git://github.com/wireapp/cryptobox-jni</connection>
+        <developerConnection>scm:git:git://github.com/wireapp/cryptobox-jni</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/wireapp/cryptobox-jni</url>
+	</scm>
+
     <licenses>
         <license>
             <name>GPL-3.0</name>
@@ -18,4 +26,27 @@
     <organization>
         <name>com.wire</name>
     </organization>
+
+    <developers>
+        <developer>
+            <id>makingthematrix</id>
+            <name>Maciej Gorywoda</name>
+            <email>maciej.gorywoda@wire.com</email>
+            <organization>Project Zeta GmbH</organization>
+            <organizationUrl>https://wire.com</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>vitorhugods</id>
+            <name>Vitor Hugo Schwaab</name>
+            <email>vitor.schwaab@wire.com</email>
+            <organization>Project Zeta GmbH</organization>
+            <organizationUrl>https://wire.com</organizationUrl>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
 </project>

--- a/android/Makefile
+++ b/android/Makefile
@@ -70,11 +70,23 @@ dist/cryptobox-android-$(VERSION).aar: dist-libs dist-jar
 	cd dist/aar && zip -r ../cryptobox-android-$(VERSION).aar *
 	rm -rf dist/aar
 
+dist/cryptobox-android-$(VERSION)-sources.jar:
+	jar -cvf dist/cryptobox-android-$(VERSION)-sources.jar -C ../src/java .
+
+dist/cryptobox-android-$(VERSION)-javadoc.jar: doc
+	jar -cvf dist/cryptobox-android-$(VERSION)-javadoc.jar -C dist/javadoc .
+
 .PHONY: dist-aar
 dist-aar: dist/cryptobox-android-$(VERSION).aar
 
+.PHONY: dist-sources
+dist-sources: dist/cryptobox-android-$(VERSION)-sources.jar
+
+.PHONY: dist-javadoc
+dist-javadoc: dist/cryptobox-android-$(VERSION)-javadoc.jar
+
 .PHONY: dist
-dist: compile dist-tar dist-aar
+dist: compile dist-tar dist-aar dist-sources dist-javadoc
 
 #############################################################################
 # cryptobox

--- a/mk/libsodium-src.mk
+++ b/mk/libsodium-src.mk
@@ -5,6 +5,6 @@ LIBSODIUM_URL     := http://download.libsodium.org/libsodium/releases/$(LIBSODIU
 build/src/$(LIBSODIUM_NAME):
 	mkdir -p build/src
 	cd build/src && \
-	wget -O $(LIBSODIUM_NAME).tar.gz $(LIBSODIUM_URL) && \
+	curl -LO $(LIBSODIUM_URL) && \
 	tar -xzf $(LIBSODIUM_NAME).tar.gz && \
 	rm $(LIBSODIUM_NAME).tar.gz

--- a/mk/version.mk
+++ b/mk/version.mk
@@ -1,1 +1,1 @@
-VERSION := 1.1.2
+VERSION := 1.1.3


### PR DESCRIPTION
In order for us to publish this to Sonatype's OSSRH, we need to upload the artifact's sources and javadoc.

This PR aims to enable that, and fix a couple of things that got broken over time:
* The latest versions of Debian don't support openjdk8 anymore. So we gotta run openjdk11.
* `wget` was failing to download `libsodium` for whatever reason. So I replaced with `curl`.