### PR TITLE
Download the stable tarball of libsodium

### DIFF
--- a/mk/libsodium-src.mk
+++ b/mk/libsodium-src.mk
@@ -1,10 +1,10 @@
 LIBSODIUM_VERSION := 1.0.18
 LIBSODIUM_NAME    := libsodium-$(LIBSODIUM_VERSION)
-LIBSODIUM_URL     := http://download.libsodium.org/libsodium/releases/$(LIBSODIUM_NAME).tar.gz
+LIBSODIUM_URL     := https://download.libsodium.org/libsodium/releases/$(LIBSODIUM_NAME)-stable.tar.gz
 
 build/src/$(LIBSODIUM_NAME):
 	mkdir -p build/src
 	cd build/src && \
 	curl -LO $(LIBSODIUM_URL) && \
-	tar -xzf $(LIBSODIUM_NAME).tar.gz && \
-	rm $(LIBSODIUM_NAME).tar.gz
+	tar -xzf $(LIBSODIUM_NAME)-stable.tar.gz --transform 's,libsodium-stable,$(LIBSODIUM_NAME),' && \
+	rm $(LIBSODIUM_NAME)-stable.tar.gz


### PR DESCRIPTION
As per the recommended instructions in https://doc.libsodium.org/installation#stable-branch

Also change http url to a https url (fixes #16)