### PR TITLE
feat: build libcryptobox with stack protector flag [WPB-1797]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust
+FROM rust:bullseye
 
 USER root
 

--- a/android/Makefile
+++ b/android/Makefile
@@ -105,7 +105,9 @@ jni/armeabi-v7a/libcryptobox.so: libsodium-armeabi-v7a | build/src/$(CRYPTOBOX_N
 		-L ../../libsodium-android-arm-v7a/lib \
 		-C ar=arm-linux-androideabi-ar \
 		-C linker=armv7a-linux-androideabi16-clang \
-		-C link_args="-Wl,-soname,libcryptobox.so"
+		-C link_args="-Wl,-soname,libcryptobox.so" \
+		-C link_arg=-fstack-protector-strong \
+		-C target_feature=+crt-static
 	mkdir -p jni/armeabi-v7a
 	cp build/src/$(CRYPTOBOX_NAME)/target/armv7-linux-androideabi/release/libcryptobox.so jni/armeabi-v7a/libcryptobox.so
 
@@ -118,7 +120,9 @@ jni/x86/libcryptobox.so: libsodium-x86 | build/src/$(CRYPTOBOX_NAME)
 		-L ../../libsodium-android-x86/lib \
 		-C ar=i686-linux-android-ar \
 		-C linker=i686-linux-android16-clang \
-		-C link_args="-Wl,-soname,libcryptobox.so"
+		-C link_args="-Wl,-soname,libcryptobox.so" \
+		-C link_arg=-fstack-protector-strong \
+		-C target_feature=+crt-static
 	mkdir -p jni/x86
 	cp build/src/$(CRYPTOBOX_NAME)/target/i686-linux-android/release/libcryptobox.so jni/x86/libcryptobox.so
 
@@ -131,7 +135,9 @@ jni/x86_64/libcryptobox.so: libsodium-x86_64 | build/src/$(CRYPTOBOX_NAME)
 		-L ../../libsodium-android-x86_64/lib \
 		-C ar=x86_64-linux-android-ar \
 		-C linker=x86_64-linux-android21-clang \
-		-C link_args="-Wl,-soname,libcryptobox.so"
+		-C link_args="-Wl,-soname,libcryptobox.so" \
+		-C link_arg=-fstack-protector-strong \
+		-C target_feature=+crt-static
 	mkdir -p jni/x86_64
 	cp build/src/$(CRYPTOBOX_NAME)/target/x86_64-linux-android/release/libcryptobox.so jni/x86_64/libcryptobox.so
 
@@ -144,7 +150,9 @@ jni/arm64-v8a/libcryptobox.so: libsodium-aarch64 | build/src/$(CRYPTOBOX_NAME)
 		-L ../../libsodium-android-armv8-a/lib \
 		-C ar=aarch64-linux-android-ar \
 		-C linker=aarch64-linux-android21-clang \
-		-C link_args="-Wl,-soname,libcryptobox.so"
+		-C link_args="-Wl,-soname,libcryptobox.so" \
+		-C link_arg=-fstack-protector-strong \
+		-C target_feature=+crt-static
 	mkdir -p jni/arm64-v8a
 	cp build/src/$(CRYPTOBOX_NAME)/target/aarch64-linux-android/release/libcryptobox.so jni/arm64-v8a/libcryptobox.so
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -19,5 +19,5 @@ LOCAL_MODULE           := cryptobox-jni
 LOCAL_SRC_FILES        := ../../src/cryptobox-jni.c
 LOCAL_SHARED_LIBRARIES := libsodium-prebuilt libcryptobox-prebuilt
 LOCAL_LDLIBS           := -llog
-LOCAL_CFLAGS           += -std=c99 -Wall
+LOCAL_CFLAGS           += -std=c99 -Wall -fstack-protector-strong
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Missing stack canaries for libcryptobox.so

### Solutions

1. add compile flags 
```
-C link_arg=-fstack-protector-strong
-C target_feature=+crt-static
```
2. specify the rust image used in the docker file for consistency 

### Testing

did run `./build-docker` locally

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
